### PR TITLE
feat: color solver with Web Worker and precision mode

### DIFF
--- a/__mocks__/workerMock.js
+++ b/__mocks__/workerMock.js
@@ -1,0 +1,9 @@
+class WorkerMock {
+    constructor() {}
+    postMessage() {}
+    terminate() {}
+    set onmessage(_fn) {}
+    set onerror(_fn) {}
+}
+
+global.Worker = WorkerMock

--- a/hacky-hours/02-design/decisions/solver-algorithm.md
+++ b/hacky-hours/02-design/decisions/solver-algorithm.md
@@ -1,0 +1,40 @@
+# ADR: Color Solver Algorithm
+
+**Date:** 2026-04-18  
+**Status:** Accepted
+
+## Decision
+
+Use a brute-force simplex grid search over palette subsets of size 1–3.
+
+## Context
+
+Given a target color and an existing palette, the solver must find the palette mix (colors + proportions) that minimizes deltaE94 against the target. The Kubelka-Munk latent space is non-linear, which rules out closed-form solutions.
+
+Three approaches were considered:
+
+| Approach | Pros | Cons |
+|---|---|---|
+| Brute force simplex grid | Simple, no dependencies, naturally caps complexity at 3 colors | Fixed granularity (step size) |
+| Gradient descent | Precise, fast convergence | Needs optimizer, local minima risk, harder to explain |
+| Greedy subset selection | Very fast | Misses cases where a 2-color combo beats either color alone |
+
+## Rationale
+
+The search space for a palette of 8 colors with 12 total parts is ~3,400 evaluations — trivially fast in a Web Worker (<100ms). Brute force wins here because the problem is small enough that exhaustive search costs nothing and eliminates the correctness risks of local minima or greedy mis-steps.
+
+The 3-color cap is also a deliberate UX constraint: mixing more than 3 paint colors for a single mix is impractical for a real painter.
+
+## Implementation
+
+- Enumerate all C(N, k) subsets for k ∈ {1, 2, 3}
+- For each subset, enumerate all integer compositions of 12 (each color gets ≥1 part)
+- For each (subset, weights) pair: blend via mixbox latent space, compute deltaE94
+- Return the combination with the lowest deltaE94; prefer fewer colors in ties
+- Run in a Web Worker to avoid blocking the UI
+
+## Consequences
+
+- Solver granularity is 1/12 of total parts per color (~8.3%). Fine enough for practical paint mixing.
+- If palette grows beyond ~10 colors, subset enumeration for k=3 still completes in well under 1 second.
+- To improve precision later, increase TOTAL_PARTS (e.g., 24) — the only tradeoff is more evaluations.

--- a/hacky-hours/04-build/BACKLOG.md
+++ b/hacky-hours/04-build/BACKLOG.md
@@ -4,12 +4,5 @@ Tasks are removed when their PR is merged. Completed work goes in CHANGELOG.md.
 
 ---
 
-## V1 — Color Solver
-
-- [ ] Design solver algorithm — research optimization approaches for Kubelka-Munk latent space (brute force vs. gradient descent vs. combinatorial search); document decision in `02-design/decisions/`
-- [ ] Implement color solver (find best palette mix to minimize deltaE94 against target)
-- [ ] Run solver in a Web Worker to avoid blocking the UI
-- [ ] Display solver result as a suggested mix the user can apply or dismiss
-
 ## Housekeeping
 

--- a/hacky-hours/04-build/CHANGELOG.md
+++ b/hacky-hours/04-build/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.2.0
+
+**Color Solver:**
+- Brute-force simplex grid solver finds the best 1–3 color mix from the palette to match a target color (minimizes deltaE94)
+- Runs in a Web Worker to avoid blocking the UI
+- Solver banner shows suggested colors, parts, and match percentage when target mode is active
+- "Apply" button sets the suggested mix on the palette directly
+- "Precision mode" checkbox doubles part granularity (12 → 24 steps) for higher accuracy at ~4.5× solve time; disabled while solving
+- Algorithm decision documented in `02-design/decisions/solver-algorithm.md`
+
 ## v1.1.0
 
 **Performance:**

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,9 +1,15 @@
 module.exports = {
-    preset: 'ts-jest',
     testEnvironment: 'jsdom',
+    transform: {
+        '^.+\\.tsx?$': ['ts-jest', {
+            tsconfig: { module: 'CommonJS' },
+            diagnostics: { ignoreCodes: [1343] },
+        }],
+    },
     moduleNameMapper: {
         "\\.(css|scss)$": "<rootDir>/__mocks__/styleMock.js",
-        "^color-name-list$": "<rootDir>/__mocks__/color-name-list.js"
+        "^color-name-list$": "<rootDir>/__mocks__/color-name-list.js",
+        "\\.worker\\.ts$": "<rootDir>/__mocks__/workerMock.js",
     },
     setupFilesAfterEnv: ['./src/setupTests.ts'],
 };

--- a/src/components/Mixer/Mixer.module.scss
+++ b/src/components/Mixer/Mixer.module.scss
@@ -29,6 +29,89 @@
         transition: opacity 500ms ease-in;
     }
 
+    .solverBanner {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.5rem 1rem;
+        background: #f5f5f5;
+        border-bottom: 1px solid #ddd;
+        flex-wrap: wrap;
+
+        .solverLabel {
+            font-weight: bold;
+            font-size: 0.85rem;
+            white-space: nowrap;
+        }
+
+        .solverChips {
+            display: flex;
+            gap: 0.5rem;
+            align-items: center;
+            flex-wrap: wrap;
+            flex: 1;
+        }
+
+        .solverChip {
+            display: flex;
+            align-items: center;
+            gap: 0.35rem;
+            font-size: 0.8rem;
+
+            .chipSwatch {
+                width: 1rem;
+                height: 1rem;
+                border-radius: 50%;
+                border: 1px solid #0003;
+                flex-shrink: 0;
+            }
+        }
+
+        .solverMatch {
+            font-size: 0.8rem;
+            color: #555;
+            white-space: nowrap;
+        }
+
+        .precisionLabel {
+            display: flex;
+            align-items: center;
+            gap: 0.35rem;
+            font-size: 0.8rem;
+            color: #555;
+            cursor: pointer;
+            margin-left: auto;
+            white-space: nowrap;
+
+            input[type='checkbox'] {
+                cursor: pointer;
+
+                &:disabled {
+                    cursor: not-allowed;
+                }
+            }
+
+            &:has(input:disabled) {
+                opacity: 0.5;
+                cursor: not-allowed;
+            }
+        }
+
+        .solverApply {
+            padding: 0.25rem 0.75rem;
+            font-size: 0.8rem;
+            cursor: pointer;
+            border: 1px solid #999;
+            border-radius: 4px;
+            background: white;
+            white-space: nowrap;
+
+            &:hover {
+                background: #e8e8e8;
+            }
+        }
+    }
+
     .colorBox {
         border: 2px solid black;
         height: 50vh;

--- a/src/components/Mixer/Mixer.test.tsx
+++ b/src/components/Mixer/Mixer.test.tsx
@@ -6,6 +6,10 @@ jest.mock('nearest-color', () => ({
     from: () => () => ({ name: 'Red', value: '#ff0000', rgb: { r: 255, g: 0, b: 0 }, distance: 0 }),
 }))
 
+jest.mock('../../data/hooks/useColorSolver', () => ({
+    useColorSolver: () => ({ result: null, isRunning: false }),
+}))
+
 beforeEach(() => {
     localStorage.clear()
 })

--- a/src/components/Mixer/Mixer.tsx
+++ b/src/components/Mixer/Mixer.tsx
@@ -22,6 +22,7 @@ import { useLocalStorage } from '../../data/hooks/useLocalStorage'
 
 import { defaultPalette } from '../../utils/palettes/defaultPalette'
 import { ColorPart } from '../../types/types'
+import { useColorSolver } from '../../data/hooks/useColorSolver'
 
 const getMixedRgbStringFromPalette = (palette: ColorPart[]): string => {
     const totalParts = palette.reduce((acc, color) => acc + color.partsInMix, 0)
@@ -68,6 +69,7 @@ const Mixer: React.FC = () => {
     const [ isUsingTargetColor, setIsUsingTargetColor ] = useState<boolean>(false)
     const [ targetColor, setTargetColor ] = useState({ h: 214, s: 43, v: 90, a: 1 })
     const [ isShowingTargetColorPicker, setIsShowingTargetColorPicker ] = useState<boolean>(false)
+    const [ precisionMode, setPrecisionMode ] = useState(false)
 
     const [ savedPalette ] = useLocalStorage('savedPalette', defaultPalette)
     const initialPalette: (any) = savedPalette
@@ -79,7 +81,8 @@ const Mixer: React.FC = () => {
         handleRemoveFromPalette,
         resetPalette,
         addToPalette,
-        updateColorName
+        updateColorName,
+        applyMix,
     } = usePaletteManager(initialPalette)
 
     // Derived values — no useEffect chains, no cascading re-renders
@@ -95,6 +98,13 @@ const Mixer: React.FC = () => {
 
     const { colorName: mixedColorName } = useColorMatching(mixedColor)
     const { colorName: targetColorName } = useColorMatching(targetRgbaString)
+
+    const { result: solverResult, isRunning: solverRunning } = useColorSolver(
+        palette,
+        targetRgbaString,
+        isUsingTargetColor && palette.length > 0,
+        precisionMode
+    )
 
     const toggleIsUsingTargetColor = useCallback(() => {
         setIsUsingTargetColor(prev => !prev)
@@ -148,6 +158,47 @@ const Mixer: React.FC = () => {
                 palette={ palette }
                 totalParts={ totalParts }
             />
+
+            { isUsingTargetColor && (
+                <div className={ styles.solverBanner } data-testid="solver-banner">
+                    <span className={ styles.solverLabel }>
+                        { solverRunning ? 'Solving…' : 'Suggested Mix:' }
+                    </span>
+                    { !solverRunning && solverResult && (
+                        <>
+                            <div className={ styles.solverChips }>
+                                { solverResult.mix.map(({ index, parts }) => (
+                                    <span key={ index } className={ styles.solverChip }>
+                                        <span
+                                            className={ styles.chipSwatch }
+                                            style={ { background: palette[index]?.rgbString } }
+                                        />
+                                        { palette[index]?.label } × { parts }
+                                    </span>
+                                )) }
+                            </div>
+                            <span className={ styles.solverMatch }>
+                                { solverResult.matchPercentage }% match
+                            </span>
+                            <button
+                                className={ styles.solverApply }
+                                onClick={ () => applyMix(solverResult.mix) }
+                            >
+                                Apply
+                            </button>
+                        </>
+                    ) }
+                    <label className={ styles.precisionLabel }>
+                        <input
+                            type="checkbox"
+                            checked={ precisionMode }
+                            disabled={ solverRunning }
+                            onChange={ e => setPrecisionMode(e.target.checked) }
+                        />
+                        Precision mode
+                    </label>
+                </div>
+            ) }
 
             <ColorSwatches
                 palette={ palette }

--- a/src/data/hooks/useColorSolver.ts
+++ b/src/data/hooks/useColorSolver.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect, useRef } from 'react'
+import { ColorPart } from '../../types/types'
+import { SolverResult } from '../../utils/colorSolver'
+
+export const useColorSolver = (
+    palette: ColorPart[],
+    targetRgbString: string,
+    enabled: boolean,
+    precision: boolean
+) => {
+    const [result, setResult] = useState<SolverResult | null>(null)
+    const [isRunning, setIsRunning] = useState(false)
+    const workerRef = useRef<Worker | null>(null)
+
+    useEffect(() => {
+        if (!enabled || palette.length === 0) {
+            setResult(null)
+            return
+        }
+
+        workerRef.current?.terminate()
+
+        const worker = new Worker(
+            new URL('../../workers/colorSolver.worker.ts', import.meta.url)
+        )
+        workerRef.current = worker
+        setIsRunning(true)
+
+        worker.onmessage = (event: MessageEvent<SolverResult>) => {
+            setResult(event.data)
+            setIsRunning(false)
+        }
+
+        worker.onerror = () => {
+            setIsRunning(false)
+        }
+
+        worker.postMessage({ palette, targetRgbString, precision })
+
+        return () => {
+            worker.terminate()
+        }
+    }, [palette, targetRgbString, enabled, precision])
+
+    return { result, isRunning }
+}

--- a/src/data/hooks/usePaletteManager.ts
+++ b/src/data/hooks/usePaletteManager.ts
@@ -31,6 +31,13 @@ const usePaletteManager = (initialPalette: ColorPart[]): PaletteManager => {
         ))
     }, [setPalette])
 
+    const applyMix = useCallback((mix: Array<{ index: number; parts: number }>) => {
+        setPalette(prev => prev.map((color, i) => {
+            const entry = mix.find(m => m.index === i)
+            return { ...color, partsInMix: entry ? entry.parts : 0 }
+        }))
+    }, [setPalette])
+
     return {
         palette,
         handleSwatchIncrement,
@@ -39,6 +46,7 @@ const usePaletteManager = (initialPalette: ColorPart[]): PaletteManager => {
         resetPalette,
         addToPalette,
         updateColorName,
+        applyMix,
     }
 }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -13,6 +13,7 @@ export type PaletteManager = {
 	resetPalette: () => void
 	addToPalette: (rgbString: string, includeRecipe: boolean) => Promise<void>
 	updateColorName: (index: number, newName: string) => void
+	applyMix: (mix: Array<{ index: number; parts: number }>) => void
 }
 
 export type Rgb = {

--- a/src/utils/colorSolver.ts
+++ b/src/utils/colorSolver.ts
@@ -1,0 +1,80 @@
+import mixbox from 'mixbox'
+import tinycolor from 'tinycolor2'
+import { normalizeRgbString, rgbToXyz, xyzToLab, deltaE94 } from './colorConversion'
+import { ColorPart } from '../types/types'
+
+export type SolverResult = {
+    mix: Array<{ index: number; parts: number }>
+    deltaE: number
+    matchPercentage: number
+}
+
+const TOTAL_PARTS_STANDARD = 12
+const TOTAL_PARTS_PRECISION = 24
+
+function blendSubset(colors: ColorPart[], weights: number[]): string {
+    const total = weights.reduce((a, b) => a + b, 0)
+    const latentMix: number[] = [0, 0, 0, 0, 0, 0, 0]
+    for (let i = 0; i < colors.length; i++) {
+        const latent = mixbox.rgbToLatent(colors[i].rgbString)
+        const fraction = weights[i] / total
+        for (let k = 0; k < 7; k++) latentMix[k] += latent[k] * fraction
+    }
+    return normalizeRgbString(mixbox.latentToRgb(latentMix))
+}
+
+function computeDeltaE(rgbString: string, target: { r: number; g: number; b: number }): number {
+    const { r, g, b } = tinycolor(rgbString).toRgb()
+    const lab1 = xyzToLab(rgbToXyz({ r, g, b }))
+    const lab2 = xyzToLab(rgbToXyz(target))
+    return deltaE94(lab1, lab2)
+}
+
+function* indexCombinations(start: number, n: number, k: number): Generator<number[]> {
+    if (k === 0) { yield []; return }
+    for (let i = start; i <= n - k; i++) {
+        for (const rest of indexCombinations(i + 1, n, k - 1)) {
+            yield [i, ...rest]
+        }
+    }
+}
+
+function* integerCompositions(total: number, parts: number): Generator<number[]> {
+    if (parts === 1) { yield [total]; return }
+    for (let first = 1; first <= total - (parts - 1); first++) {
+        for (const rest of integerCompositions(total - first, parts - 1)) {
+            yield [first, ...rest]
+        }
+    }
+}
+
+export function solve(palette: ColorPart[], targetRgbString: string, precision = false): SolverResult {
+    const TOTAL_PARTS = precision ? TOTAL_PARTS_PRECISION : TOTAL_PARTS_STANDARD
+    const { r, g, b } = tinycolor(targetRgbString).toRgb()
+    const targetRgb = { r, g, b }
+    const n = palette.length
+
+    let bestDeltaE = Infinity
+    let bestMix: Array<{ index: number; parts: number }> = []
+
+    const maxSubsetSize = Math.min(3, n)
+    for (let subsetSize = 1; subsetSize <= maxSubsetSize; subsetSize++) {
+        for (const indices of indexCombinations(0, n, subsetSize)) {
+            const colors = indices.map(i => palette[i])
+            for (const weights of integerCompositions(TOTAL_PARTS, subsetSize)) {
+                const mixed = blendSubset(colors, weights)
+                const de = computeDeltaE(mixed, targetRgb)
+                if (de < bestDeltaE) {
+                    bestDeltaE = de
+                    bestMix = indices.map((idx, i) => ({ index: idx, parts: weights[i] }))
+                }
+            }
+        }
+    }
+
+    return {
+        mix: bestMix,
+        deltaE: bestDeltaE,
+        matchPercentage: parseFloat(Math.max(0, 100 - bestDeltaE).toFixed(2)),
+    }
+}

--- a/src/workers/colorSolver.worker.ts
+++ b/src/workers/colorSolver.worker.ts
@@ -1,0 +1,8 @@
+import { solve } from '../utils/colorSolver'
+import { ColorPart } from '../types/types'
+
+addEventListener('message', (event: MessageEvent<{ palette: ColorPart[]; targetRgbString: string; precision: boolean }>) => {
+    const { palette, targetRgbString, precision } = event.data
+    const result = solve(palette, targetRgbString, precision)
+    postMessage(result)
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
     "compilerOptions": {
         "jsx": "react",
+        "target": "ES2017",
+        "module": "ESNext",
         "esModuleInterop": true,
         "moduleResolution": "node",
         "allowSyntheticDefaultImports": true,

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -6,7 +6,7 @@ module.exports = {
     mode: 'development',
     output: {
         path: path.resolve(__dirname, 'dist'),
-        filename: 'bundle.js',
+        filename: '[name].bundle.js',
     },
     module: {
         rules: [
@@ -69,6 +69,13 @@ module.exports = {
         hot: true,
         compress: true,
         historyApiFallback: true,
+    },
+    optimization: {
+        splitChunks: {
+            // Only split synchronous (entry-point) chunks.
+            // Worker bundles must be self-contained — their deps can't be loaded via importScripts.
+            chunks: 'initial',
+        },
     },
     stats: {
         errorDetails: true,


### PR DESCRIPTION
## Summary
- Brute-force simplex grid solver finds the best 1–3 color mix from the palette to match a target color (minimizes deltaE94)
- Runs in a Web Worker so the UI stays responsive during solve
- Solver banner shows suggested colors, parts, and match percentage when target mode is active; Apply button sets the mix directly
- Precision mode checkbox doubles part granularity (12 → 24 steps) for higher accuracy at ~4.5× solve time
- Algorithm decision documented in `hacky-hours/02-design/decisions/solver-algorithm.md`

## Test plan
- [ ] Enable target color mode — solver banner appears and resolves to a suggestion
- [ ] Click Apply — palette parts update to match the suggestion
- [ ] Toggle Precision mode — solver re-runs and match percentage improves
- [ ] Precision mode checkbox is disabled while solving
- [ ] All 116 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)