### PR TITLE
feat: use paint library name as swatch label

### DIFF
--- a/hacky-hours/04-build/BACKLOG.md
+++ b/hacky-hours/04-build/BACKLOG.md
@@ -6,10 +6,6 @@ Tasks are removed when their PR is merged. Completed work goes in CHANGELOG.md.
 
 ## V1.3.0 — Paint Library
 
-- [ ] Add `beekman/paint-crawl` as a git submodule; configure `CopyWebpackPlugin` to copy `paint-crawl/data/*.json` to `dist/paint-data/` and serve from dev server
-- [ ] Create `usePaintLibrary` hook — fetches `/paint-data/<medium>.json` on demand, derives sorted brand list, filters to `hex_available: true`, returns alphabetized color list
-- [ ] Create `PaintLibrary` component — medium dropdown, optional brand dropdown, scrollable color list with inline swatches; calls `addToPalette` on selection
-- [ ] Add "Paint Library" tab to `AddColorUIComponent` alongside existing color picker tab
 - [ ] When adding a color from the Paint Library, use the paint's name (from the library) as the swatch label rather than the auto-generated color name
 
 ## Housekeeping

--- a/hacky-hours/04-build/CHANGELOG.md
+++ b/hacky-hours/04-build/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.3.0
+
+**Paint Library:**
+- Browse ~53K real-world paint colors across 21 mediums (oil, acrylic, watercolor, gouache, and more) via the `beekman/paint-crawl` submodule
+- "Paint Library" tab added to the add-color panel alongside the existing color picker
+- Filter by medium and optionally by brand; colors listed alphabetically with inline swatches
+- Clicking a color adds it directly to the palette
+- Paint data fetched on demand per medium, cached in memory — never bundled into the main JS chunk
+- Oil Paint loads by default when the tab is opened
+
 ## v1.2.0
 
 **Color Solver:**

--- a/src/components/PaintLibrary/PaintLibrary.tsx
+++ b/src/components/PaintLibrary/PaintLibrary.tsx
@@ -28,7 +28,7 @@ const MEDIUMS: { value: string; label: string }[] = [
 ]
 
 interface PaintLibraryProps {
-    addToPalette: (rgbString: string, includeRecipe: boolean) => Promise<void>
+    addToPalette: (rgbString: string, includeRecipe: boolean, label?: string) => Promise<void>
 }
 
 const PaintLibrary: React.FC<PaintLibraryProps> = ({ addToPalette }) => {
@@ -74,7 +74,7 @@ const PaintLibrary: React.FC<PaintLibraryProps> = ({ addToPalette }) => {
                             key={ `${ color.brand }-${ color.name }-${ i }` }
                             className={ styles.colorRow }
                             role="listitem"
-                            onClick={ () => addToPalette(rgbString, false) }
+                            onClick={ () => addToPalette(rgbString, false, color.name) }
                             title={ `${ color.brand } — ${ color.name }` }
                         >
                             <span

--- a/src/data/hooks/useSwatchAdder.tsx
+++ b/src/data/hooks/useSwatchAdder.tsx
@@ -6,16 +6,15 @@ import { getColorName } from '../../utils/colorName'
 export const useSwatchAdder = (initialPalette: ColorPart[]) => {
     const [ palette, setPalette ] = useState<ColorPart[]>(initialPalette)
 
-    const addToPalette = async (rgbString: string, includeRecipe: boolean) => {
+    const addToPalette = async (rgbString: string, includeRecipe: boolean, label?: string) => {
         if (isColorInPalette(rgbString)) {
             console.error("Selected color already in palette", rgbString)
             return
         }
-        const hexColor = tinycolor(rgbString).toHexString()
-        const colorName = await getColorName(hexColor.substring(1))
+        const resolvedLabel = label ?? await getColorName(tinycolor(rgbString).toHexString().substring(1))
         const newColor: ColorPart = {
             rgbString,
-            label: colorName,
+            label: resolvedLabel,
             partsInMix: 0,
         }
         if (includeRecipe) {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -11,7 +11,7 @@ export type PaletteManager = {
 	handleSwatchDecrement: (index: number) => void
 	handleRemoveFromPalette: (index: number) => void
 	resetPalette: () => void
-	addToPalette: (rgbString: string, includeRecipe: boolean) => Promise<void>
+	addToPalette: (rgbString: string, includeRecipe: boolean, label?: string) => Promise<void>
 	updateColorName: (index: number, newName: string) => void
 	applyMix: (mix: Array<{ index: number; parts: number }>) => void
 }


### PR DESCRIPTION
## Summary

- Colors added from the Paint Library now use the paint's real name as the swatch label (e.g. "Cadmium Red Medium") instead of the auto-generated nearest-color name
- Colors added via the color picker are unchanged — they still get the nearest-color name
- `addToPalette` gains an optional `label` param; if provided it's used directly, skipping the async color name lookup

## Test plan

- [ ] Add a color from the Paint Library — swatch label matches the name shown in the library
- [ ] Add a color via the color picker — swatch label is still auto-generated
- [ ] 116 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)