### PR TITLE
feat: prefix brand name in paint library when All Brands is selected

### DIFF
--- a/src/components/PaintLibrary/PaintLibrary.tsx
+++ b/src/components/PaintLibrary/PaintLibrary.tsx
@@ -69,12 +69,13 @@ const PaintLibrary: React.FC<PaintLibraryProps> = ({ addToPalette }) => {
                 ) }
                 { !isLoading && filtered.map((color, i) => {
                     const rgbString = `rgb(${ color.rgb })`
+                    const displayLabel = brand ? color.name : `${ color.brand } ${ color.name }`
                     return (
                         <button
                             key={ `${ color.brand }-${ color.name }-${ i }` }
                             className={ styles.colorRow }
                             role="listitem"
-                            onClick={ () => addToPalette(rgbString, false, color.name) }
+                            onClick={ () => addToPalette(rgbString, false, displayLabel) }
                             title={ `${ color.brand } — ${ color.name }` }
                         >
                             <span
@@ -82,8 +83,8 @@ const PaintLibrary: React.FC<PaintLibraryProps> = ({ addToPalette }) => {
                                 style={ { background: color.hex } }
                                 aria-hidden="true"
                             />
-                            <span className={ styles.colorName }>{ color.name }</span>
-                            <span className={ styles.brandName }>{ color.brand }</span>
+                            <span className={ styles.colorName }>{ displayLabel }</span>
+                            { brand && <span className={ styles.brandName }>{ color.brand }</span> }
                         </button>
                     )
                 }) }

--- a/src/data/hooks/usePaintLibrary.ts
+++ b/src/data/hooks/usePaintLibrary.ts
@@ -47,7 +47,11 @@ export const usePaintLibrary = (medium: string, brand: string) => {
 
     const filtered = state.colors
         .filter(c => !brand || c.brand === brand)
-        .sort((a, b) => a.name.localeCompare(b.name))
+        .sort((a, b) => {
+            const keyA = brand ? a.name : `${a.brand} ${a.name}`
+            const keyB = brand ? b.name : `${b.brand} ${b.name}`
+            return keyA.localeCompare(keyB)
+        })
 
     return { ...state, filtered }
 }


### PR DESCRIPTION
## Summary

- When "All Brands" is selected, colors are displayed and sorted as "Brand Color Name" (e.g. "Da Vinci Alizarin Crimson") — prevents confusion when multiple brands share the same color name
- When a specific brand is filtered, display reverts to color name only with the brand shown as a secondary label (unchanged behavior)
- Swatch label added to the palette follows the same logic

## Test plan

- [ ] All Brands: list shows "Brand Name" format, sorted alphabetically by that combined string
- [ ] Filter by brand: list shows color name only, secondary brand label visible, sorted by name
- [ ] Adding a color from All Brands view uses the full "Brand Name" as the swatch label
- [ ] 116 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)