### PR TITLE
fix: move dark mode toggle to fixed bottom-right corner

### DIFF
--- a/src/components/ColorBoxUI/ColorBoxUI.module.scss
+++ b/src/components/ColorBoxUI/ColorBoxUI.module.scss
@@ -28,19 +28,4 @@
         }
     }
 
-    .toggleTheme {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        font-size: 0.6rem;
-
-        svg {
-            height: 1.6rem;
-            width: 1.6rem;
-        }
-
-        label {
-            cursor: pointer;
-        }
-    }
 }

--- a/src/components/ColorBoxUI/ColorBoxUI.test.tsx
+++ b/src/components/ColorBoxUI/ColorBoxUI.test.tsx
@@ -13,8 +13,6 @@ describe('<ColorBoxUI />', () => {
         addToPalette: jest.fn(),
         hasPartsInMix: false,
         palette: [],
-        theme: 'light' as const,
-        toggleTheme: jest.fn(),
     }
 
     it('renders without crashing', () => {

--- a/src/components/ColorBoxUI/ColorBoxUI.tsx
+++ b/src/components/ColorBoxUI/ColorBoxUI.tsx
@@ -10,7 +10,6 @@ import { hsvaToRgba } from '@uiw/color-convert'
 import { FaArrowDown } from 'react-icons/fa'
 import { TbTargetArrow, TbTargetOff } from 'react-icons/tb'
 import { VscDebugRestart } from 'react-icons/vsc'
-import { MdLightMode, MdDarkMode } from 'react-icons/md'
 
 interface ColorBoxUIProps {
     mixedColor: string
@@ -21,11 +20,9 @@ interface ColorBoxUIProps {
     isSavable: boolean
     addToPalette: (color: string, includeRecipe: boolean) => void
     hasPartsInMix: boolean
-    theme: 'light' | 'dark'
-    toggleTheme: () => void
 }
 
-const ColorBoxUI: React.FC<ColorBoxUIProps> = ({ mixedColor, isUsingTargetColor, targetColor, resetPalette, toggleIsUsingTargetColor, isSavable, addToPalette, hasPartsInMix, theme, toggleTheme }) => {
+const ColorBoxUI: React.FC<ColorBoxUIProps> = ({ mixedColor, isUsingTargetColor, targetColor, resetPalette, toggleIsUsingTargetColor, isSavable, addToPalette, hasPartsInMix }) => {
     const mixedIsDark = useMemo(() => tinycolor(mixedColor).isDark(), [mixedColor])
     const targetIsDark = useMemo(() => tinycolor(hsvaToRgba(targetColor)).isDark(), [targetColor])
     const contrastColor = mixedIsDark ? 'white' : 'black'
@@ -75,16 +72,6 @@ const ColorBoxUI: React.FC<ColorBoxUIProps> = ({ mixedColor, isUsingTargetColor,
                     <TbTargetArrow data-testid="target-arrow-icon" /> :
                     <TbTargetOff data-testid="target-off-icon" /> }
                 <label className={ styles.buttonTargetColor }>Target</label>
-            </button>
-            <button
-                className={ styles.toggleTheme }
-                onClick={ toggleTheme }
-                style={ { color: contrastColor } }
-                aria-label={ theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode' }
-                data-testid="theme-toggle"
-            >
-                { theme === 'dark' ? <MdLightMode /> : <MdDarkMode /> }
-                <label className={ styles.buttonTheme }>{ theme === 'dark' ? 'Light' : 'Dark' }</label>
             </button>
         </div>
     )

--- a/src/components/Mixer/Mixer.module.scss
+++ b/src/components/Mixer/Mixer.module.scss
@@ -112,6 +112,30 @@
         }
     }
 
+    .themeToggle {
+        position: fixed;
+        bottom: 1rem;
+        right: 1rem;
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: 50%;
+        width: 2.5rem;
+        height: 2.5rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        font-size: 1.2rem;
+        color: var(--color-text-primary);
+        opacity: 0.7;
+        transition: opacity 0.2s;
+        z-index: 100;
+
+        &:hover {
+            opacity: 1;
+        }
+    }
+
     .colorBox {
         border: 2px solid var(--color-border-strong);
         height: 50vh;

--- a/src/components/Mixer/Mixer.tsx
+++ b/src/components/Mixer/Mixer.tsx
@@ -24,6 +24,7 @@ import { useTheme } from '../../data/hooks/useTheme'
 import { defaultPalette } from '../../utils/palettes/defaultPalette'
 import { ColorPart } from '../../types/types'
 import { useColorSolver } from '../../data/hooks/useColorSolver'
+import { MdLightMode, MdDarkMode } from 'react-icons/md'
 
 const getMixedRgbStringFromPalette = (palette: ColorPart[]): string => {
     const totalParts = palette.reduce((acc, color) => acc + color.partsInMix, 0)
@@ -151,8 +152,6 @@ const Mixer: React.FC = () => {
                     isSavable={ isSavable }
                     addToPalette={ addToPalette }
                     hasPartsInMix={ hasPartsInMix }
-                    theme={ theme }
-                    toggleTheme={ toggleTheme }
                 />
 
                 <div className={ styles.transparencyBox }>
@@ -213,6 +212,15 @@ const Mixer: React.FC = () => {
                 updateColorName={ updateColorName }
                 totalParts={ totalParts }
             />
+
+            <button
+                className={ styles.themeToggle }
+                onClick={ toggleTheme }
+                aria-label={ theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode' }
+                data-testid="theme-toggle"
+            >
+                { theme === 'dark' ? <MdLightMode /> : <MdDarkMode /> }
+            </button>
 
             <AddColorUIComponent
                 showAddColorPicker={ showAddColorPicker }


### PR DESCRIPTION
## Summary

Moves the dark/light toggle from the color box controls to a fixed circular button in the bottom-right corner of the window. Cleaner separation from the mix controls.

## Test plan

- [ ] Toggle button appears fixed at bottom-right on all screen sizes
- [ ] Clicking toggles dark/light mode as before
- [ ] Color box controls (Reset, Save, Target) are unchanged
- [ ] 116 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)