### PR TITLE
feat: v1.5.0 preferences panel

### DIFF
--- a/hacky-hours/03-roadmap/ROADMAP.md
+++ b/hacky-hours/03-roadmap/ROADMAP.md
@@ -13,26 +13,44 @@ Core palette builder, physics-based mixing, and target color matching.
 - localStorage persistence
 - Deployed on Netlify
 
-## V1 — Color Solver
+## Shipped — v1.1.0
 
-The app can already tell you how well a mix matches a target. V1 closes the loop: given a target color, calculate the best mix automatically.
+Performance overhaul and test coverage.
 
-**Milestone goal:** A user sets a target color, triggers the solver, and receives a suggested mix from their existing palette.
+- Eliminated cascading `useEffect` re-renders — palette changes now trigger 1 render instead of 3–4
+- Lazy-load `color-name-list` + `nearest-color` into a separate chunk (~500KB deferred)
+- Unit and integration tests for core hooks and Mixer orchestrator
 
-**Features:**
-- Color solver algorithm (search/optimize over palette combinations to minimize deltaE94)
-- Web Worker for non-blocking computation
-- Solver result displayed as a suggested mix the user can apply or adjust
+## Shipped — v1.2.0
 
-## V2+ — Commercial Paint Database
+Color solver.
 
-Allow users to browse and select commercial paint colors by brand and name, with accurate RGB values.
+- Brute-force simplex grid solver finds the best 1–3 color mix from the palette to match a target
+- Runs in a Web Worker to avoid blocking the UI
+- Solver banner with suggested mix, match percentage, Apply button, and Precision mode toggle
 
-**Dependencies:** Requires a separate web crawler application to populate a database from online paint store listings. Build this last.
+## Shipped — v1.3.0
 
-**Features:**
-- Paint brand/product browser
-- Search by name (e.g. "Winsor & Newton Cadmium Yellow")
-- One-click add to palette with accurate RGB
-- Crawler app (separate project)
-- Database + lookup API
+Paint Library.
+
+- Browse ~53K real-world paint colors across 21 mediums via the `beekman/paint-crawl` submodule
+- Filter by medium and brand; colors listed alphabetically with inline swatches
+- Paint data fetched on demand per medium, never bundled into the main JS chunk
+- When All Brands is selected, colors are sorted and labeled as "Brand Name"
+
+## Shipped — v1.4.0
+
+Dark mode.
+
+- Full dark mode driven by CSS custom properties across the entire component tree
+- Respects `prefers-color-scheme` on first visit; persists user choice to localStorage
+- Dark/Light toggle button fixed to bottom-right corner
+
+## v1.5.0 — Preferences Panel
+
+Replace the standalone dark mode toggle with a unified Preferences system.
+
+- Gear icon button fixed to bottom-right; visually muted on desktop until cursor is within ~100px
+- Clicking gear opens a Preferences banner above the button
+- Banner contains: Dark/Light mode toggle + Suggested Mix Precision mode toggle
+- Precision mode remains in the solver banner as well

--- a/hacky-hours/04-build/BACKLOG.md
+++ b/hacky-hours/04-build/BACKLOG.md
@@ -8,7 +8,7 @@ Tasks are removed when their PR is merged. Completed work goes in CHANGELOG.md.
 
 - [x] **Gear button + proximity fade** — Add a gear icon button fixed to bottom-right (replacing the current theme toggle position). On desktop, button is fully transparent at rest and fades in when the cursor is within ~100px of the button. On mobile/touch, button is always visible at reduced opacity (no hover available). Toggles `showPreferences` state.
 - [x] **Preferences banner** — When `showPreferences` is true, render a banner anchored above the gear button (similar layout to the solver banner). Banner closes when the gear is clicked again or the user clicks outside.
-- [ ] **Wire toggles into banner** — Move the Dark/Light mode toggle into the Preferences banner. Add a copy of the Precision mode checkbox labeled "Suggested Mix Precision mode" that shares the same `precisionMode` state as the existing solver banner checkbox.
+- [x] **Wire toggles into banner** — Move the Dark/Light mode toggle into the Preferences banner. Add a copy of the Precision mode checkbox labeled "Suggested Mix Precision mode" that shares the same `precisionMode` state as the existing solver banner checkbox.
 
 ## Housekeeping
 

--- a/hacky-hours/04-build/BACKLOG.md
+++ b/hacky-hours/04-build/BACKLOG.md
@@ -4,5 +4,11 @@ Tasks are removed when their PR is merged. Completed work goes in CHANGELOG.md.
 
 ---
 
+## v1.5.0 — Preferences Panel
+
+- [x] **Gear button + proximity fade** — Add a gear icon button fixed to bottom-right (replacing the current theme toggle position). On desktop, button is fully transparent at rest and fades in when the cursor is within ~100px of the button. On mobile/touch, button is always visible at reduced opacity (no hover available). Toggles `showPreferences` state.
+- [ ] **Preferences banner** — When `showPreferences` is true, render a banner anchored above the gear button (similar layout to the solver banner). Banner closes when the gear is clicked again or the user clicks outside.
+- [ ] **Wire toggles into banner** — Move the Dark/Light mode toggle into the Preferences banner. Add a copy of the Precision mode checkbox labeled "Suggested Mix Precision mode" that shares the same `precisionMode` state as the existing solver banner checkbox.
+
 ## Housekeeping
 

--- a/hacky-hours/04-build/BACKLOG.md
+++ b/hacky-hours/04-build/BACKLOG.md
@@ -7,7 +7,7 @@ Tasks are removed when their PR is merged. Completed work goes in CHANGELOG.md.
 ## v1.5.0 — Preferences Panel
 
 - [x] **Gear button + proximity fade** — Add a gear icon button fixed to bottom-right (replacing the current theme toggle position). On desktop, button is fully transparent at rest and fades in when the cursor is within ~100px of the button. On mobile/touch, button is always visible at reduced opacity (no hover available). Toggles `showPreferences` state.
-- [ ] **Preferences banner** — When `showPreferences` is true, render a banner anchored above the gear button (similar layout to the solver banner). Banner closes when the gear is clicked again or the user clicks outside.
+- [x] **Preferences banner** — When `showPreferences` is true, render a banner anchored above the gear button (similar layout to the solver banner). Banner closes when the gear is clicked again or the user clicks outside.
 - [ ] **Wire toggles into banner** — Move the Dark/Light mode toggle into the Preferences banner. Add a copy of the Precision mode checkbox labeled "Suggested Mix Precision mode" that shares the same `precisionMode` state as the existing solver banner checkbox.
 
 ## Housekeeping

--- a/hacky-hours/ITERATION.md
+++ b/hacky-hours/ITERATION.md
@@ -1,3 +1,29 @@
+# Iteration Log — post v1.4.0
+
+## Captured
+
+### Dark mode: missing text color on Apply button and + button (bug)
+Two elements inherited black text color instead of using the theme variable in dark mode:
+- "Apply" button in the Suggested Mix solver banner (`Mixer.module.scss` `.solverApply`)
+- "+" add-to-palette button (`AddColorUiComponent.module.scss` `>button`)
+
+Both fixed by adding `color: var(--color-text-primary)`.
+
+## Synthesized
+
+| Item | Type | Design doc affected |
+|---|---|---|
+| Dark mode incomplete — missing color vars on two buttons | Bug fix | none (implementation-only) |
+
+## Prioritized
+
+- **Hotfix:** Both fixes applied directly; ready to commit.
+
+## Status
+Triaged. Fixes applied.
+
+---
+
 # Iteration Log — post v1.2.0
 
 ## Captured

--- a/hacky-hours/ITERATION.md
+++ b/hacky-hours/ITERATION.md
@@ -19,8 +19,21 @@ Both fixed by adding `color: var(--color-text-primary)`.
 
 - **Hotfix:** Both fixes applied directly; ready to commit.
 
+### Preferences panel (new feature)
+Replace the standalone Dark Mode toggle with a Preferences system:
+
+- A gear icon button, fixed bottom-right (same position as current theme toggle)
+- On desktop: button is visually muted at rest; becomes visible when the cursor is near or over the bottom-right corner of the screen
+- Clicking the gear opens a Preferences banner/panel
+- Clicking the gear opens a Preferences banner that slides in above the button
+- The banner contains:
+  - Dark/Light mode toggle (moved from its current standalone position)
+  - "Suggested Mix Precision mode" toggle (copied from the solver banner; "Precision mode" label stays in the solver banner)
+- When the Preferences banner is closed, neither toggle is visible in it
+- Desktop proximity behavior: gear button fades in when the cursor is within ~100px of the button; muted otherwise
+
 ## Status
-Triaged. Fixes applied.
+Triaged. Hotfix committed. Preferences panel queued in BACKLOG.md as v1.5.0 (3 tasks). ROADMAP.md updated to reflect v1.1–v1.4 shipped.
 
 ---
 

--- a/src/components/AddColorUIComponent/AddColorUiComponent.module.scss
+++ b/src/components/AddColorUIComponent/AddColorUiComponent.module.scss
@@ -4,6 +4,7 @@
     >button {
         background-color: transparent;
         border: 0;
+        color: var(--color-text-primary);
         font-size: 3rem;
         position: absolute;
         width: 5rem;

--- a/src/components/Mixer/Mixer.module.scss
+++ b/src/components/Mixer/Mixer.module.scss
@@ -115,29 +115,24 @@
 
     .preferencesBanner {
         position: fixed;
-        bottom: 4rem;
-        right: 1rem;
+        bottom: 1rem;
+        left: 1rem;
+        right: calc(1rem + 2.5rem + 0.5rem);
+        height: 2.5rem;
         background: var(--color-surface);
         border: 1px solid var(--color-border);
         border-radius: 4px;
-        padding: 0.75rem 1rem;
+        padding: 0 1rem;
         display: flex;
-        flex-direction: column;
-        gap: 0.75rem;
-        min-width: 14rem;
+        flex-direction: row;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 1rem;
         z-index: 100;
         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 
-        .preferenceRow {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            gap: 0.75rem;
-            font-size: 0.85rem;
-            color: var(--color-text-secondary);
-        }
-
         .preferenceThemeButton {
+            position: relative;
             background: transparent;
             border: none;
             cursor: pointer;
@@ -147,8 +142,24 @@
             align-items: center;
             padding: 0;
 
-            &:hover {
-                color: var(--color-text-secondary);
+            .preferenceThemeLabel {
+                position: absolute;
+                bottom: calc(100% + 0.4rem);
+                right: 0;
+                font-size: 0.75rem;
+                color: var(--color-text-primary);
+                background: var(--color-surface-alt);
+                border: 1px solid var(--color-border);
+                border-radius: 4px;
+                padding: 0.2rem 0.4rem;
+                white-space: nowrap;
+                opacity: 0;
+                pointer-events: none;
+                transition: opacity 0.15s ease;
+            }
+
+            &:hover .preferenceThemeLabel {
+                opacity: 1;
             }
         }
 
@@ -159,6 +170,7 @@
             font-size: 0.8rem;
             color: var(--color-text-secondary);
             cursor: pointer;
+            white-space: nowrap;
 
             input[type='checkbox'] {
                 cursor: pointer;

--- a/src/components/Mixer/Mixer.module.scss
+++ b/src/components/Mixer/Mixer.module.scss
@@ -113,7 +113,7 @@
         }
     }
 
-    .themeToggle {
+    .gearButton {
         position: fixed;
         bottom: 1rem;
         right: 1rem;
@@ -128,12 +128,20 @@
         cursor: pointer;
         font-size: 1.2rem;
         color: var(--color-text-primary);
-        opacity: 0.7;
+        opacity: 0;
         transition: opacity 0.2s;
         z-index: 100;
 
+        &.gearVisible {
+            opacity: 0.7;
+        }
+
         &:hover {
             opacity: 1;
+        }
+
+        @media (hover: none) {
+            opacity: 0.7;
         }
     }
 

--- a/src/components/Mixer/Mixer.module.scss
+++ b/src/components/Mixer/Mixer.module.scss
@@ -104,6 +104,7 @@
             border: 1px solid var(--color-border-subtle);
             border-radius: 4px;
             background: var(--color-input-bg);
+            color: var(--color-text-primary);
             white-space: nowrap;
 
             &:hover {

--- a/src/components/Mixer/Mixer.module.scss
+++ b/src/components/Mixer/Mixer.module.scss
@@ -127,6 +127,52 @@
         min-width: 14rem;
         z-index: 100;
         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+
+        .preferenceRow {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 0.75rem;
+            font-size: 0.85rem;
+            color: var(--color-text-secondary);
+        }
+
+        .preferenceThemeButton {
+            background: transparent;
+            border: none;
+            cursor: pointer;
+            font-size: 1.1rem;
+            color: var(--color-text-primary);
+            display: flex;
+            align-items: center;
+            padding: 0;
+
+            &:hover {
+                color: var(--color-text-secondary);
+            }
+        }
+
+        .preferencePrecisionLabel {
+            display: flex;
+            align-items: center;
+            gap: 0.35rem;
+            font-size: 0.8rem;
+            color: var(--color-text-secondary);
+            cursor: pointer;
+
+            input[type='checkbox'] {
+                cursor: pointer;
+
+                &:disabled {
+                    cursor: not-allowed;
+                }
+            }
+
+            &:has(input:disabled) {
+                opacity: 0.5;
+                cursor: not-allowed;
+            }
+        }
     }
 
     .gearButton {

--- a/src/components/Mixer/Mixer.module.scss
+++ b/src/components/Mixer/Mixer.module.scss
@@ -113,6 +113,22 @@
         }
     }
 
+    .preferencesBanner {
+        position: fixed;
+        bottom: 4rem;
+        right: 1rem;
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: 4px;
+        padding: 0.75rem 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        min-width: 14rem;
+        z-index: 100;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+    }
+
     .gearButton {
         position: fixed;
         bottom: 1rem;

--- a/src/components/Mixer/Mixer.tsx
+++ b/src/components/Mixer/Mixer.tsx
@@ -245,16 +245,6 @@ const Mixer: React.FC = () => {
 
             { showPreferences && (
                 <div ref={ bannerRef } className={ styles.preferencesBanner } data-testid="preferences-banner">
-                    <div className={ styles.preferenceRow }>
-                        <span>{ theme === 'dark' ? 'Dark mode' : 'Light mode' }</span>
-                        <button
-                            className={ styles.preferenceThemeButton }
-                            onClick={ toggleTheme }
-                            aria-label={ theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode' }
-                        >
-                            { theme === 'dark' ? <MdLightMode /> : <MdDarkMode /> }
-                        </button>
-                    </div>
                     <label className={ styles.preferencePrecisionLabel }>
                         <input
                             type="checkbox"
@@ -264,6 +254,16 @@ const Mixer: React.FC = () => {
                         />
                         Suggested Mix Precision mode
                     </label>
+                    <button
+                        className={ styles.preferenceThemeButton }
+                        onClick={ toggleTheme }
+                        aria-label={ theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode' }
+                    >
+                        <span className={ styles.preferenceThemeLabel }>
+                            { theme === 'dark' ? 'Light mode' : 'Dark mode' }
+                        </span>
+                        { theme === 'dark' ? <MdLightMode /> : <MdDarkMode /> }
+                    </button>
                 </div>
             ) }
 

--- a/src/components/Mixer/Mixer.tsx
+++ b/src/components/Mixer/Mixer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react'
+import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react'
 import styles from './Mixer.module.scss'
 
 //components
@@ -24,7 +24,7 @@ import { useTheme } from '../../data/hooks/useTheme'
 import { defaultPalette } from '../../utils/palettes/defaultPalette'
 import { ColorPart } from '../../types/types'
 import { useColorSolver } from '../../data/hooks/useColorSolver'
-import { MdLightMode, MdDarkMode } from 'react-icons/md'
+import { MdSettings } from 'react-icons/md'
 
 const getMixedRgbStringFromPalette = (palette: ColorPart[]): string => {
     const totalParts = palette.reduce((acc, color) => acc + color.partsInMix, 0)
@@ -66,9 +66,12 @@ const isColorInPalette = (rgbString: string, palette: ColorPart[]): boolean => {
 }
 
 const Mixer: React.FC = () => {
-    const { theme, toggleTheme } = useTheme()
+    const { theme } = useTheme()
 
     const [ showAddColorPicker, setShowAddColorPicker ] = useState(false)
+    const [ showPreferences, setShowPreferences ] = useState(false)
+    const [ isNearGear, setIsNearGear ] = useState(false)
+    const gearRef = useRef<HTMLButtonElement>(null)
     const [ addColor, setAddColor ] = useState({ h: 214, s: 43, v: 90, a: 1 })
     const [ isUsingTargetColor, setIsUsingTargetColor ] = useState<boolean>(false)
     const [ targetColor, setTargetColor ] = useState({ h: 214, s: 43, v: 90, a: 1 })
@@ -109,6 +112,18 @@ const Mixer: React.FC = () => {
         isUsingTargetColor && palette.length > 0,
         precisionMode
     )
+
+    useEffect(() => {
+        const handleMouseMove = (e: MouseEvent) => {
+            if (!gearRef.current) return
+            const rect = gearRef.current.getBoundingClientRect()
+            const cx = rect.left + rect.width / 2
+            const cy = rect.top + rect.height / 2
+            setIsNearGear(Math.sqrt((e.clientX - cx) ** 2 + (e.clientY - cy) ** 2) < 100)
+        }
+        window.addEventListener('mousemove', handleMouseMove)
+        return () => window.removeEventListener('mousemove', handleMouseMove)
+    }, [])
 
     const toggleIsUsingTargetColor = useCallback(() => {
         setIsUsingTargetColor(prev => !prev)
@@ -214,12 +229,13 @@ const Mixer: React.FC = () => {
             />
 
             <button
-                className={ styles.themeToggle }
-                onClick={ toggleTheme }
-                aria-label={ theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode' }
-                data-testid="theme-toggle"
+                ref={ gearRef }
+                className={ `${ styles.gearButton }${ isNearGear || showPreferences ? ` ${ styles.gearVisible }` : '' }` }
+                onClick={ () => setShowPreferences(prev => !prev) }
+                aria-label="Preferences"
+                data-testid="gear-button"
             >
-                { theme === 'dark' ? <MdLightMode /> : <MdDarkMode /> }
+                <MdSettings />
             </button>
 
             <AddColorUIComponent

--- a/src/components/Mixer/Mixer.tsx
+++ b/src/components/Mixer/Mixer.tsx
@@ -72,6 +72,7 @@ const Mixer: React.FC = () => {
     const [ showPreferences, setShowPreferences ] = useState(false)
     const [ isNearGear, setIsNearGear ] = useState(false)
     const gearRef = useRef<HTMLButtonElement>(null)
+    const bannerRef = useRef<HTMLDivElement>(null)
     const [ addColor, setAddColor ] = useState({ h: 214, s: 43, v: 90, a: 1 })
     const [ isUsingTargetColor, setIsUsingTargetColor ] = useState<boolean>(false)
     const [ targetColor, setTargetColor ] = useState({ h: 214, s: 43, v: 90, a: 1 })
@@ -124,6 +125,20 @@ const Mixer: React.FC = () => {
         window.addEventListener('mousemove', handleMouseMove)
         return () => window.removeEventListener('mousemove', handleMouseMove)
     }, [])
+
+    useEffect(() => {
+        if (!showPreferences) return
+        const handleClickOutside = (e: MouseEvent) => {
+            if (
+                bannerRef.current && !bannerRef.current.contains(e.target as Node) &&
+                gearRef.current && !gearRef.current.contains(e.target as Node)
+            ) {
+                setShowPreferences(false)
+            }
+        }
+        document.addEventListener('mousedown', handleClickOutside)
+        return () => document.removeEventListener('mousedown', handleClickOutside)
+    }, [ showPreferences ])
 
     const toggleIsUsingTargetColor = useCallback(() => {
         setIsUsingTargetColor(prev => !prev)
@@ -227,6 +242,12 @@ const Mixer: React.FC = () => {
                 updateColorName={ updateColorName }
                 totalParts={ totalParts }
             />
+
+            { showPreferences && (
+                <div ref={ bannerRef } className={ styles.preferencesBanner } data-testid="preferences-banner">
+                    {/* toggles added in task 3 */}
+                </div>
+            ) }
 
             <button
                 ref={ gearRef }

--- a/src/components/Mixer/Mixer.tsx
+++ b/src/components/Mixer/Mixer.tsx
@@ -24,7 +24,7 @@ import { useTheme } from '../../data/hooks/useTheme'
 import { defaultPalette } from '../../utils/palettes/defaultPalette'
 import { ColorPart } from '../../types/types'
 import { useColorSolver } from '../../data/hooks/useColorSolver'
-import { MdSettings } from 'react-icons/md'
+import { MdSettings, MdLightMode, MdDarkMode } from 'react-icons/md'
 
 const getMixedRgbStringFromPalette = (palette: ColorPart[]): string => {
     const totalParts = palette.reduce((acc, color) => acc + color.partsInMix, 0)
@@ -66,7 +66,7 @@ const isColorInPalette = (rgbString: string, palette: ColorPart[]): boolean => {
 }
 
 const Mixer: React.FC = () => {
-    const { theme } = useTheme()
+    const { theme, toggleTheme } = useTheme()
 
     const [ showAddColorPicker, setShowAddColorPicker ] = useState(false)
     const [ showPreferences, setShowPreferences ] = useState(false)
@@ -245,7 +245,25 @@ const Mixer: React.FC = () => {
 
             { showPreferences && (
                 <div ref={ bannerRef } className={ styles.preferencesBanner } data-testid="preferences-banner">
-                    {/* toggles added in task 3 */}
+                    <div className={ styles.preferenceRow }>
+                        <span>{ theme === 'dark' ? 'Dark mode' : 'Light mode' }</span>
+                        <button
+                            className={ styles.preferenceThemeButton }
+                            onClick={ toggleTheme }
+                            aria-label={ theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode' }
+                        >
+                            { theme === 'dark' ? <MdLightMode /> : <MdDarkMode /> }
+                        </button>
+                    </div>
+                    <label className={ styles.preferencePrecisionLabel }>
+                        <input
+                            type="checkbox"
+                            checked={ precisionMode }
+                            disabled={ solverRunning }
+                            onChange={ e => setPrecisionMode(e.target.checked) }
+                        />
+                        Suggested Mix Precision mode
+                    </label>
                 </div>
             ) }
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,4 +1,4 @@
-@import './theme.scss';
+@use './theme.scss';
 
 .w-color-editable-input:nth-of-type(4) {
     visibility: hidden;


### PR DESCRIPTION
## Summary

- Replaces standalone dark mode toggle with a gear icon button fixed to the bottom-right corner
- On desktop the gear is invisible at rest and fades in when the cursor is within ~100px; always visible at reduced opacity on touch devices
- Clicking the gear opens a full-width horizontal preferences banner expanding left along the bottom of the screen
- Banner contains: dark/light mode toggle (with hover tooltip label) and Suggested Mix Precision mode checkbox (synced with solver banner); closes on outside click
- Fixed dark mode text color missing on the solver Apply button and the palette + button
- Fixed deprecated Sass `@import` → `@use`

## Test plan

- [ ] Gear button invisible at rest on desktop; fades in on cursor proximity (~100px); stays visible while banner is open
- [ ] Gear button visible at reduced opacity on mobile/touch viewport
- [ ] Banner opens on gear click, closes on gear click or outside click
- [ ] Dark/light mode toggle works; label appears as tooltip on hover without shifting layout
- [ ] Precision mode checkbox in banner stays in sync with the one in the solver banner
- [ ] Apply button and + button use correct text color in dark mode
- [ ] No Sass deprecation warnings in build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)