### PR TITLE
feat: 4-color solver in precision mode, persist precision + dark mode to localStorage

### DIFF
--- a/src/components/Mixer/Mixer.tsx
+++ b/src/components/Mixer/Mixer.tsx
@@ -77,7 +77,7 @@ const Mixer: React.FC = () => {
     const [ isUsingTargetColor, setIsUsingTargetColor ] = useState<boolean>(false)
     const [ targetColor, setTargetColor ] = useState({ h: 214, s: 43, v: 90, a: 1 })
     const [ isShowingTargetColorPicker, setIsShowingTargetColorPicker ] = useState<boolean>(false)
-    const [ precisionMode, setPrecisionMode ] = useState(false)
+    const [ precisionMode, setPrecisionMode ] = useLocalStorage('precisionMode', false)
 
     const [ savedPalette ] = useLocalStorage('savedPalette', defaultPalette)
     const initialPalette: (any) = savedPalette

--- a/src/data/hooks/useLocalStorage.ts
+++ b/src/data/hooks/useLocalStorage.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import React, { useState, useEffect } from "react"
 
 export const useLocalStorage = <T>(key: string, initialValue: T) => {
 	const [storedValue, setStoredValue] = useState<T>(() => {
@@ -18,5 +18,5 @@ export const useLocalStorage = <T>(key: string, initialValue: T) => {
 		}
 	}, [key, storedValue])
 
-	return [storedValue, setStoredValue]
+	return [storedValue, setStoredValue] as [T, React.Dispatch<React.SetStateAction<T>>]
 }

--- a/src/utils/colorSolver.ts
+++ b/src/utils/colorSolver.ts
@@ -57,7 +57,7 @@ export function solve(palette: ColorPart[], targetRgbString: string, precision =
     let bestDeltaE = Infinity
     let bestMix: Array<{ index: number; parts: number }> = []
 
-    const maxSubsetSize = Math.min(3, n)
+    const maxSubsetSize = Math.min(precision ? 4 : 3, n)
     for (let subsetSize = 1; subsetSize <= maxSubsetSize; subsetSize++) {
         for (const indices of indexCombinations(0, n, subsetSize)) {
             const colors = indices.map(i => palette[i])


### PR DESCRIPTION
## Summary

- Precision mode solver now searches up to 4-color mixes (was 3); standard mode unchanged at 3
- `precisionMode` state persisted to localStorage — survives page reloads
- Dark mode already persisted via `useTheme`; confirmed no change needed
- Fixed `useLocalStorage` return type to a proper tuple so TypeScript infers destructuring correctly

## Test plan

- [ ] In precision mode, solver can suggest 4-color mixes when palette has 4+ colors
- [ ] Standard mode still caps at 3 colors
- [ ] Precision mode checkbox state survives page reload
- [ ] Dark/light mode preference survives page reload (regression check)
- [ ] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)